### PR TITLE
Added platform to unicorn gem for windows compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :assets do
 end
 
 group :production, :staging do
-  gem 'unicorn'
+  gem 'unicorn', :platforms => :ruby
 end
 
 group :development, :test do


### PR DESCRIPTION
A unicorn dependency won't work on windows at all, and since it is not needed in development adding this platform restriction fixes the issues and now the app runs fine on my windows machine and should not affect any *nix user.
