### PR TITLE
Asset compression for Heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'uglifier', '>= 1.3.0'
 group :production, :staging do
   gem 'unicorn', :platforms => :ruby
   gem 'rails_12factor'
+  gem 'heroku_rails_deflate'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,10 @@ GEM
       railties (>= 3.1.1)
       sass-rails (>= 3.1.1)
     google-analytics-rails (0.0.4)
+    heroku_rails_deflate (1.0.3)
+      actionpack (>= 3.2.13)
+      activesupport (>= 3.2.13)
+      rack (>= 1.4.5)
     hike (1.2.3)
     i18n (0.6.9)
     jquery-cookie-rails (1.3.1.1)
@@ -202,6 +206,7 @@ DEPENDENCIES
   factory_girl_rails
   font-awesome-sass-rails (~> 3.0)
   google-analytics-rails
+  heroku_rails_deflate
   jquery-cookie-rails
   jquery-rails
   launchy

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -8,15 +8,15 @@ BikeCommuteChallenge::Application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
-  # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.serve_static_assets = false
+  # Enable Rails's static asset server (Apache or nginx will already do this, Heroku does not)
+  config.serve_static_assets = true
 
   # Compress JavaScripts and CSS
   config.assets.compress = true
   config.assets.js_compressor = :uglifier
 
-  # Don't fallback to assets pipeline if a precompiled asset is missed
-  config.assets.compile = false
+  # Do fallback to assets pipeline if a precompiled asset is missed
+  config.assets.compile = true
 
   # Generate digests for assets URLs
   config.assets.digest = true

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -8,15 +8,15 @@ BikeCommuteChallenge::Application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
-  # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.serve_static_assets = false
+  # Enable Rails's static asset server (Apache or nginx will already do this, Heroku does not)
+  config.serve_static_assets = true
 
   # Compress JavaScripts and CSS
   config.assets.compress = true
   config.assets.js_compressor = :uglifier
 
-  # Don't fallback to assets pipeline if a precompiled asset is missed
-  config.assets.compile = false
+  # Do fallback to assets pipeline if a precompiled asset is missed
+  config.assets.compile = true
 
   # Generate digests for assets URLs
   config.assets.digest = true


### PR DESCRIPTION
Heroku does not provide a frontend web server, so asset compression needs to happen at the application level (since we're not using a CDN). The heroku_rails_deflate gem handles all the logic for doing this.
