### PR TITLE
Removed Dash in YML

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -9,7 +9,7 @@
   </div>
   <div class="span4">
     <% unless current_membership %>
-      <%= link_to t("dashboard.user.no-team"), teams_path, class: "btn btn-orange pull-right" %>
+      <%= link_to t("dashboard.user.no_team"), teams_path, class: "btn btn-orange pull-right" %>
     <% end %>
     <div class="clearfix"></div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,7 +63,7 @@ en:
       mileage: "Your Mileage"
       commutes: "Your Commutes"
       participation: "Your Participation"
-      no-team: "Join or create a team to start competing"
+      no_team: "Join or create a team to start competing"
 
   help:
     title: "Welcome to the BCA's Commuter Challenge!"


### PR DESCRIPTION
The no-team variable was unlike the others, which use underscores in them. This threw off Sublime's syntax highlighting, and has been replaced with no_team
