### PR TITLE
Add simple sponsors page

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,4 +4,7 @@ class HomeController < ApplicationController
 
   def rules
   end
+
+  def sponsors
+  end
 end

--- a/app/views/home/rules.html.erb
+++ b/app/views/home/rules.html.erb
@@ -93,23 +93,8 @@
         </p>
 
         <p>
-          There will be an awards party and celebration (location and date TBD but it will be in September). Last year we had great door prizes thanks to our amazing sponsors including:
+          There will be an awards party and celebration (location and date TBD but it will be in September). Last year we had great door prizes thanks to our <%= link_to "amazing sponsors", sponsors_path %>.
         </p>
-
-        <ul>
-          <li>The Alaska Club</li>
-          <li>The Alaska Railroad</li>
-          <li>The Bear Tooth and Moose’s Tooth</li>
-          <li>The Bicycle Shop</li>
-          <li>Blue Sky Studio</li>
-          <li>City Diner</li>
-          <li>Fire Island Rustic Bakery</li>
-          <li>Great Harvest Bread Co.</li>
-          <li>Midnight Sun Brewing Co.</li>
-          <li>REI</li>
-          <li>Resource Data, Inc.</li>
-          <li>Steamdot</li>
-        </ul>
 
         <p>
           And of course there will be some fantastic trophies for the winners that you can display in your office for the entire year.

--- a/app/views/home/sponsors.html.erb
+++ b/app/views/home/sponsors.html.erb
@@ -1,0 +1,43 @@
+<% title "Sponsors" %>
+
+<div class="row">
+  <div class="span12">
+    <h1 class="welcome">Sponsors</h1>
+  </div>
+</div>
+
+<div class="row">
+  <div class="span8 offset2 rules">
+    <h3>2014 Sponsors</h3>
+
+    <ul>
+      <li><%= link_to "American Institute of Architects ", "http://www.aiaalaska.org/" %></li>
+      <li><%= link_to "Blue Sky Studio", "http://www.callbluesky.com/" %></li>
+      <li><%= link_to "Resource Data, Inc", "http://www.resdat.com" %></li>
+      <li><%= link_to "Spenard Roadhouse", "http://www.spenardroadhouse.com/" %></li>
+    </ul>
+  </div>
+</div>
+
+<div class="row">
+  <div class="span8 offset2 rules">
+    <h3>2013 Sponsors</h3>
+
+    <ul>
+      <li><%= link_to "American Institute of Architects ", "http://www.aiaalaska.org/" %></li>
+      <li><%= link_to "Blue Sky Studio", "http://www.callbluesky.com/" %></li>
+      <li><%= link_to "City Diner", "http://citydineranchorage.com/" %></li>
+      <li><%= link_to "Fire Island Rustic Bakery", "http://fireislandbread.com/" %></li>
+      <li><%= link_to "Great Harvest Bread Co.", "http://greatharvestanchorage.com/" %></li>
+      <li><%= link_to "Midnight Sun Brewing Co.", "http://midnightsunbrewing.com/" %></li>
+      <li><%= link_to "REI", "http://www.rei.com/stores/anchorage.html" %></li>
+      <li><%= link_to "Resource Data, Inc", "http://www.resdat.com" %></li>
+      <li><%= link_to "Spenard Roadhouse", "http://www.spenardroadhouse.com/" %></li>
+      <li><%= link_to "Steamdot", "https://www.steamdot.com/" %></li>
+      <li><%= link_to "The Alaska Club", "http://www.thealaskaclub.com/" %></li>
+      <li><%= link_to "The Alaska Railroad", "http://alaskarailroad.com/" %></li>
+      <li><%= link_to "The Bear Tooth", "http://beartooththeatre.net/" %> and <%= link_to "Moose’s Tooth", "http://moosestooth.net/" %></li>
+      <li><%= link_to "The Bicycle Shop", "http://www.bikeshopak.com/" %></li>
+    </ul>
+  </div>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -15,6 +15,7 @@
           <% end %>
           <%= header_link_to "Teams", teams_path %>
           <%= header_link_to "Rules", rules_path %>
+          <%= header_link_to "Sponsors", sponsors_path %>
         </ul>
 
         <%= render "layouts/user_session" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ BikeCommuteChallenge::Application.routes.draw do
   get "dashboard" => "dashboard#index"
   get "help" => "home#index"
   get "rules" => "home#rules"
+  get "sponsors" => "home#sponsors"
 
   devise_for :users, controllers: { registrations: :registrations }
 


### PR DESCRIPTION
In the future, there's likely to be a Sponsor model, which each competition will `has_many` of, which would also support image/logos. In the interest of time, however, this only include hardcoded list, broken down by year.
