### PR TITLE
Use Calendar.today to get current date

### DIFF
--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -56,7 +56,7 @@ class Ride < ActiveRecord::Base
   end
 
   def validate_date_is_recent
-    if date? && date <= 15.days.ago
+    if date? && date <= Calendar.today - 15.days
       errors.add :date, "must be within the past 2 weeks"
     end
   end

--- a/spec/models/competition_spec.rb
+++ b/spec/models/competition_spec.rb
@@ -65,7 +65,7 @@ describe Competition do
     end
 
     it "includes competitions that start today" do
-      competition = FactoryGirl.create(:competition, start_on: Date.today, end_on: 4.months.from_now)
+      competition = FactoryGirl.create(:competition, start_on: Calendar.today, end_on: 4.months.from_now)
       expect(Competition.active).to include(competition)
     end
 

--- a/spec/models/ride_spec.rb
+++ b/spec/models/ride_spec.rb
@@ -54,10 +54,10 @@ describe Ride do
     end
 
     it "must be logged within two weeks of current date" do
-      ride = FactoryGirl.build(:ride, date: 15.days.ago)
+      ride = FactoryGirl.build(:ride, date: Calendar.today - 15.days)
       ride.should_not be_valid
       ride.should have(1).error_on(:date)
-      ride.date = 14.days.ago
+      ride.date = Calendar.today - 14.days
       ride.should be_valid
     end
   end


### PR DESCRIPTION
There were a couple places using `Date.today` or `X.days`, which does not use the timezone specified in the app config. Switching to `Calendar.today` (which respects the timezone) should fix the failing tests we see periodically on Travis.

Will close #76
